### PR TITLE
[bix bug]; fix graph prob in dp case, solve dynamic shape problem;

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -520,7 +520,9 @@ class LogitsProcessor(nn.Module):
 
         if self.do_tensor_parallel_all_gather_dp_attn:
             if logits_metadata.can_run_graph:
-                global_logits = logits.view(self.dp_size, -1, logits.size(-1))
+                global_logits = logits.view(
+                    -1, local_hidden_states.shape[0], logits.shape[1]
+                )
                 logits = global_logits[self.dp_rank]
             else:
                 logits, global_logits = (


### PR DESCRIPTION
解决了dp场景下，成图超过卡数就会报错的问题，报错截图如下
<img width="910" height="121" alt="image" src="https://github.com/user-attachments/assets/160327d2-2f44-4d65-9a81-85f227cf0e7d" />
